### PR TITLE
Ignore leading /api/v1 and the like

### DIFF
--- a/lib/stub-stub/server.js
+++ b/lib/stub-stub/server.js
@@ -32,11 +32,17 @@ server.get('/', function(req, res){
 // -- GET: /cars/1
 // -- GET: /cars?ids[]=1&ids[]=2&ids[]=3
 
+var prefixRegex = /\/(api|v\d+)(?=\/)/g;
+
 server.get('/*', function(req, res){
+
+  var path = req.path.replace(prefixRegex, '');
+  var url = req.originalUrl.replace(prefixRegex, '');
+
   Logger.log('GET:', req.originalUrl, JSON.stringify(req.query));
 
-  var r  = new Resource({ url: req.originalUrl });
-  var rs = new Resources({ path: req.path, ids: req.query.ids });
+  var r  = new Resource({ url: url });
+  var rs = new Resources({ path: path, ids: req.query.ids });
 
   if (req.query.ids || rs.isBaseResourceType()) {
     res.json(rs.asJSON());


### PR DESCRIPTION
This will simplify our environment configs. `/foo`, `/v1/foo`, `/api/foo`, `/api/v1/foo`, `/api/v2/foo`: all the same, just `/foo`.

You might want to put this code somewhere else? Dunno
